### PR TITLE
Fix code scanning alert no. 1: CSRF protection not enabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
   before_action :set_layout
 
   private


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_4/security/code-scanning/1](https://github.com/Brook-5686/Ruby_4/security/code-scanning/1)

To fix the CSRF vulnerability, we need to enable CSRF protection in the `ApplicationController` class. This can be done by adding a call to `protect_from_forgery` with the `:exception` strategy, which raises an exception if an invalid CSRF token is provided. This ensures that any request without a valid CSRF token will be rejected, preventing CSRF attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
